### PR TITLE
make scale more smoothly

### DIFF
--- a/lib/src/core/photo_view_gesture_detector.dart
+++ b/lib/src/core/photo_view_gesture_detector.dart
@@ -66,6 +66,7 @@ class PhotoViewGestureDetector extends StatelessWidget {
           hitDetector: hitDetector, debugOwner: this, validateAxis: axis),
       (PhotoViewGestureRecognizer instance) {
         instance
+          ..dragStartBehavior = DragStartBehavior.start
           ..onStart = onScaleStart
           ..onUpdate = onScaleUpdate
           ..onEnd = onScaleEnd;


### PR DESCRIPTION
According to GestureDector.dragStartBehavior description between DragStartBehavior.start and DragStartBehavior.down, to make image scalable more smoothly, we should set PhotoViewGestureRecognizer dragStartBehavior to DragStartBehavior.start.