### PR TITLE
keep PhotoView state

### DIFF
--- a/lib/photo_view.dart
+++ b/lib/photo_view.dart
@@ -404,7 +404,7 @@ class PhotoView extends StatefulWidget {
   }
 }
 
-class _PhotoViewState extends State<PhotoView> {
+class _PhotoViewState extends State<PhotoView> with AutomaticKeepAliveClientMixin{
   // image retrieval
 
   // controller
@@ -542,6 +542,9 @@ class _PhotoViewState extends State<PhotoView> {
       },
     );
   }
+
+  @override
+  bool get wantKeepAlive => true;
 }
 
 /// The default [ScaleStateCycle]


### PR DESCRIPTION
For now, PhotoView in gallery will reset state when scrolling to another page. The fix is for keepling scale state.