### PR TITLE
Proper zooming with "enablePanAlways" enabled

### DIFF
--- a/lib/src/core/photo_view_core.dart
+++ b/lib/src/core/photo_view_core.dart
@@ -156,7 +156,7 @@ class PhotoViewCoreState extends State<PhotoViewCore>
     updateMultiple(
       scale: newScale,
       position: widget.enablePanAlways
-          ? delta
+          ? delta * details.scale
           : clampPosition(position: delta * details.scale),
       rotation:
           widget.enableRotation ? _rotationBefore! + details.rotation : null,


### PR DESCRIPTION
Before this change, zooming a PhotoView constructed with `enablePanAlways: true` would use the wrong scaling pivot.