### PR TITLE
added `wantKeepAlive` parameter to make it optional

### DIFF
--- a/lib/photo_view.dart
+++ b/lib/photo_view.dart
@@ -237,6 +237,7 @@ class PhotoView extends StatefulWidget {
     required this.imageProvider,
     this.loadingBuilder,
     this.backgroundDecoration,
+    this.wantKeepAlive = false,
     this.gaplessPlayback = false,
     this.heroAttributes,
     this.scaleStateChangedCallback,
@@ -273,6 +274,7 @@ class PhotoView extends StatefulWidget {
     required this.child,
     this.childSize,
     this.backgroundDecoration,
+    this.wantKeepAlive = false,
     this.heroAttributes,
     this.scaleStateChangedCallback,
     this.enableRotation = false,
@@ -311,6 +313,11 @@ class PhotoView extends StatefulWidget {
 
   /// Changes the background behind image, defaults to `Colors.black`.
   final BoxDecoration? backgroundDecoration;
+
+  /// This is used to keep the state of an image in the gallery (e.g. scale state).
+  /// `false` -> resets the state (default)
+  /// `true`  -> keeps the state
+  final bool wantKeepAlive;
 
   /// This is used to continue showing the old image (`true`), or briefly show
   /// nothing (`false`), when the `imageProvider` changes. By default it's set
@@ -545,7 +552,7 @@ class _PhotoViewState extends State<PhotoView>
   }
 
   @override
-  bool get wantKeepAlive => true;
+  bool get wantKeepAlive => widget.wantKeepAlive;
 }
 
 /// The default [ScaleStateCycle]

--- a/lib/photo_view_gallery.dart
+++ b/lib/photo_view_gallery.dart
@@ -106,6 +106,7 @@ class PhotoViewGallery extends StatefulWidget {
     required this.pageOptions,
     this.loadingBuilder,
     this.backgroundDecoration,
+    this.wantKeepAlive = false,
     this.gaplessPlayback = false,
     this.reverse = false,
     this.pageController,
@@ -129,6 +130,7 @@ class PhotoViewGallery extends StatefulWidget {
     required this.builder,
     this.loadingBuilder,
     this.backgroundDecoration,
+    this.wantKeepAlive = false,
     this.gaplessPlayback = false,
     this.reverse = false,
     this.pageController,
@@ -161,6 +163,9 @@ class PhotoViewGallery extends StatefulWidget {
 
   /// Mirror to [PhotoView.backgroundDecoration]
   final BoxDecoration? backgroundDecoration;
+
+  /// Mirror to [PhotoView.wantKeepAlive]
+  final bool wantKeepAlive;
 
   /// Mirror to [PhotoView.gaplessPlayback]
   final bool gaplessPlayback;
@@ -246,6 +251,7 @@ class _PhotoViewGalleryState extends State<PhotoViewGallery> {
             child: pageOption.child,
             childSize: pageOption.childSize,
             backgroundDecoration: widget.backgroundDecoration,
+            wantKeepAlive: widget.wantKeepAlive,
             controller: pageOption.controller,
             scaleStateController: pageOption.scaleStateController,
             customSize: widget.customSize,
@@ -270,6 +276,7 @@ class _PhotoViewGalleryState extends State<PhotoViewGallery> {
             imageProvider: pageOption.imageProvider,
             loadingBuilder: widget.loadingBuilder,
             backgroundDecoration: widget.backgroundDecoration,
+            wantKeepAlive: widget.wantKeepAlive,
             controller: pageOption.controller,
             scaleStateController: pageOption.scaleStateController,
             customSize: widget.customSize,


### PR DESCRIPTION
This introduces a `wantKeepAlive` parameter to make the feature (_keep PhotoView state #452_, which keeps an image scale state) optional.

Comparing it with the iOS Photo app, I suggest the default value to be `false` :)

closes #478