### PR TITLE
Update example app README with macOS instructions

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -7,3 +7,5 @@ After cloning, run the following command inside this directory:
 ```
 flutter create .
 ```
+
+For running on macOS, you will need to allow outgoing network connections for the sample images to load. For that, open `macos/Runner.xcworkspace` in Xcode, click on the `Runner` target, activate the `Signing & Capabilities` tab and check the `Outgoing Connections (Client)` checkbox under `App Sandbox (Debug and Profile)`.


### PR DESCRIPTION
This PR adds instructions for running the example app on macOS where it is required to allow outgoing network connections, or else image loading will fail.