### PR TITLE
Flutter Update: 2.10.0 - Fix: Looking up a deactivated widget's ancestor is unsafe fix

### DIFF
--- a/lib/src/core/photo_view_core.dart
+++ b/lib/src/core/photo_view_core.dart
@@ -258,7 +258,7 @@ class PhotoViewCoreState extends State<PhotoViewCore>
 
     cachedScaleBoundaries = widget.scaleBoundaries;
 
-    _scaleAnimation = AnimationController(vsync: this)
+    _scaleAnimationController = AnimationController(vsync: this)
       ..addListener(handleScaleAnimation)
       ..addStatusListener(onAnimationStatus);
     _positionAnimationController = AnimationController(vsync: this)

--- a/lib/src/core/photo_view_core.dart
+++ b/lib/src/core/photo_view_core.dart
@@ -108,14 +108,10 @@ class PhotoViewCoreState extends State<PhotoViewCore>
   double? _scaleBefore;
   double? _rotationBefore;
 
-  late final AnimationController _scaleAnimationController =
-      AnimationController(vsync: this)
-        ..addListener(handleScaleAnimation)
-        ..addStatusListener(onAnimationStatus);
+  late final AnimationController _scaleAnimationController;
   Animation<double>? _scaleAnimation;
 
-  late final AnimationController _positionAnimationController =
-      AnimationController(vsync: this)..addListener(handlePositionAnimate);
+  late final AnimationController _positionAnimationController;
   Animation<Offset>? _positionAnimation;
 
   late final AnimationController _rotationAnimationController =
@@ -261,6 +257,12 @@ class PhotoViewCoreState extends State<PhotoViewCore>
     addAnimateOnScaleStateUpdate(animateOnScaleStateUpdate);
 
     cachedScaleBoundaries = widget.scaleBoundaries;
+
+    _scaleAnimation = AnimationController(vsync: this)
+      ..addListener(handleScaleAnimation)
+      ..addStatusListener(onAnimationStatus);
+    _positionAnimationController = AnimationController(vsync: this)
+      ..addListener(handlePositionAnimate);
   }
 
   void animateOnScaleStateUpdate(double prevScale, double nextScale) {


### PR DESCRIPTION
With the new stable version `2.10.0` of Flutter, there is a new problem.
When building this widget with some images, it works fine.
But when leaving/disposing this widget, there is crash report in the console that says `Looking up a deactivated widget's ancestor is unsafe`.
The solution for this problem was to initialize the controller inside `initState` to ensure, that everything was initialized correctly in the lifecycle of a stateful widget.
When the widget is disposed, there is no problem disposing these controllers.