### PR TITLE
Support enable double tap to zoom in on half

### DIFF
--- a/lib/photo_view.dart
+++ b/lib/photo_view.dart
@@ -1,7 +1,6 @@
 library photo_view;
 
 import 'package:flutter/material.dart';
-
 import 'package:photo_view/src/controller/photo_view_controller.dart';
 import 'package:photo_view/src/controller/photo_view_scalestate_controller.dart';
 import 'package:photo_view/src/core/photo_view_core.dart';
@@ -560,7 +559,9 @@ class _PhotoViewState extends State<PhotoView>
 PhotoViewScaleState defaultScaleStateCycle(PhotoViewScaleState actual) {
   switch (actual) {
     case PhotoViewScaleState.initial:
-      return PhotoViewScaleState.covering;
+      return PhotoViewScaleState.zoomedInOnHalf;
+    case PhotoViewScaleState.zoomedInOnHalf:
+      return PhotoViewScaleState.initial;
     case PhotoViewScaleState.covering:
       return PhotoViewScaleState.originalSize;
     case PhotoViewScaleState.originalSize:

--- a/lib/src/photo_view_scale_state.dart
+++ b/lib/src/photo_view_scale_state.dart
@@ -4,6 +4,7 @@ enum PhotoViewScaleState {
   covering,
   originalSize,
   zoomedIn,
+  zoomedInOnHalf,
   zoomedOut,
 }
 

--- a/lib/src/utils/photo_view_utils.dart
+++ b/lib/src/utils/photo_view_utils.dart
@@ -21,6 +21,11 @@ double getScaleForScaleState(
           scaleBoundaries);
     case PhotoViewScaleState.originalSize:
       return _clampSize(1.0, scaleBoundaries);
+    case PhotoViewScaleState.zoomedInOnHalf:
+      return _clampSize(
+        (scaleBoundaries.initialScale + scaleBoundaries.maxScale) * 0.5,
+        scaleBoundaries,
+      );
     // Will never be reached
     default:
       return 0;


### PR DESCRIPTION
It would be more convenient to allow users to double-tap to zoom in on the image and double-tap again to return the image to its original state.