### PR TITLE
Pass through semanticLabel

### DIFF
--- a/lib/photo_view.dart
+++ b/lib/photo_view.dart
@@ -38,6 +38,7 @@ export 'src/utils/photo_view_hero_attributes.dart';
 ///            ),
 ///          ),
 ///  backgroundDecoration: BoxDecoration(color: Colors.black),
+///  semanticLabel: 'Some label',
 ///  gaplessPlayback: false,
 ///  customSize: MediaQuery.of(context).size,
 ///  heroAttributes: const HeroAttributes(
@@ -68,6 +69,7 @@ export 'src/utils/photo_view_hero_attributes.dart';
 ///  ),
 ///  childSize: const Size(220.0, 250.0),
 ///  backgroundDecoration: BoxDecoration(color: Colors.black),
+///  semanticLabel: 'Some label',
 ///  gaplessPlayback: false,
 ///  customSize: MediaQuery.of(context).size,
 ///  heroAttributes: const HeroAttributes(
@@ -238,6 +240,7 @@ class PhotoView extends StatefulWidget {
     this.loadingBuilder,
     this.backgroundDecoration,
     this.wantKeepAlive = false,
+    this.semanticLabel,
     this.gaplessPlayback = false,
     this.heroAttributes,
     this.scaleStateChangedCallback,
@@ -296,6 +299,7 @@ class PhotoView extends StatefulWidget {
     this.enablePanAlways,
   })  : errorBuilder = null,
         imageProvider = null,
+        semanticLabel = null,
         gaplessPlayback = false,
         loadingBuilder = null,
         super(key: key);
@@ -318,6 +322,11 @@ class PhotoView extends StatefulWidget {
   /// `false` -> resets the state (default)
   /// `true`  -> keeps the state
   final bool wantKeepAlive;
+
+  /// A Semantic description of the image.
+  ///
+  /// Used to provide a description of the image to TalkBack on Android, and VoiceOver on iOS.
+  final String? semanticLabel;
 
   /// This is used to continue showing the old image (`true`), or briefly show
   /// nothing (`false`), when the `imageProvider` changes. By default it's set
@@ -526,6 +535,7 @@ class _PhotoViewState extends State<PhotoView>
                 imageProvider: widget.imageProvider!,
                 loadingBuilder: widget.loadingBuilder,
                 backgroundDecoration: backgroundDecoration,
+                semanticLabel: widget.semanticLabel,
                 gaplessPlayback: widget.gaplessPlayback,
                 heroAttributes: widget.heroAttributes,
                 scaleStateChangedCallback: widget.scaleStateChangedCallback,

--- a/lib/photo_view_gallery.dart
+++ b/lib/photo_view_gallery.dart
@@ -280,6 +280,7 @@ class _PhotoViewGalleryState extends State<PhotoViewGallery> {
             controller: pageOption.controller,
             scaleStateController: pageOption.scaleStateController,
             customSize: widget.customSize,
+            semanticLabel: pageOption.semanticLabel,
             gaplessPlayback: widget.gaplessPlayback,
             heroAttributes: pageOption.heroAttributes,
             scaleStateChangedCallback: scaleStateChangedCallback,
@@ -322,6 +323,7 @@ class PhotoViewGalleryPageOptions {
     Key? key,
     required this.imageProvider,
     this.heroAttributes,
+    this.semanticLabel,
     this.minScale,
     this.maxScale,
     this.initialScale,
@@ -343,6 +345,7 @@ class PhotoViewGalleryPageOptions {
 
   PhotoViewGalleryPageOptions.customChild({
     required this.child,
+    this.semanticLabel,
     this.childSize,
     this.heroAttributes,
     this.minScale,
@@ -367,6 +370,9 @@ class PhotoViewGalleryPageOptions {
 
   /// Mirror to [PhotoView.heroAttributes]
   final PhotoViewHeroAttributes? heroAttributes;
+
+  /// Mirror to [PhotoView.semanticLabel]
+  final String? semanticLabel;
 
   /// Mirror to [PhotoView.minScale]
   final dynamic minScale;

--- a/lib/src/core/photo_view_core.dart
+++ b/lib/src/core/photo_view_core.dart
@@ -25,6 +25,7 @@ class PhotoViewCore extends StatefulWidget {
     Key? key,
     required this.imageProvider,
     required this.backgroundDecoration,
+    required this.semanticLabel,
     required this.gaplessPlayback,
     required this.heroAttributes,
     required this.enableRotation,
@@ -64,11 +65,13 @@ class PhotoViewCore extends StatefulWidget {
     required this.disableGestures,
     required this.enablePanAlways,
   })  : imageProvider = null,
+        semanticLabel = null,
         gaplessPlayback = false,
         super(key: key);
 
   final Decoration? backgroundDecoration;
   final ImageProvider? imageProvider;
+  final String? semanticLabel;
   final bool? gaplessPlayback;
   final PhotoViewHeroAttributes? heroAttributes;
   final bool enableRotation;
@@ -379,6 +382,7 @@ class PhotoViewCoreState extends State<PhotoViewCore>
         ? widget.customChild!
         : Image(
             image: widget.imageProvider!,
+            semanticLabel: widget.semanticLabel,
             gaplessPlayback: widget.gaplessPlayback ?? false,
             filterQuality: widget.filterQuality,
             width: scaleBoundaries.childSize.width * scale,

--- a/lib/src/photo_view_wrappers.dart
+++ b/lib/src/photo_view_wrappers.dart
@@ -11,6 +11,7 @@ class ImageWrapper extends StatefulWidget {
     required this.imageProvider,
     required this.loadingBuilder,
     required this.backgroundDecoration,
+    required this.semanticLabel,
     required this.gaplessPlayback,
     required this.heroAttributes,
     required this.scaleStateChangedCallback,
@@ -38,6 +39,7 @@ class ImageWrapper extends StatefulWidget {
   final LoadingBuilder? loadingBuilder;
   final ImageErrorWidgetBuilder? errorBuilder;
   final BoxDecoration backgroundDecoration;
+  final String? semanticLabel;
   final bool gaplessPlayback;
   final PhotoViewHeroAttributes? heroAttributes;
   final ValueChanged<PhotoViewScaleState>? scaleStateChangedCallback;
@@ -182,6 +184,7 @@ class _ImageWrapperState extends State<ImageWrapper> {
     return PhotoViewCore(
       imageProvider: widget.imageProvider,
       backgroundDecoration: widget.backgroundDecoration,
+      semanticLabel: widget.semanticLabel,
       gaplessPlayback: widget.gaplessPlayback,
       enableRotation: widget.enableRotation,
       heroAttributes: widget.heroAttributes,


### PR DESCRIPTION
Pass through [`semanticLabel`](https://api.flutter.dev/flutter/widgets/Image/semanticLabel.html) for [screen readers](https://docs.flutter.dev/development/accessibility-and-localization/accessibility).