### PR TITLE
feature/strictscale: add possibility to restrict user scale, fix issue #85

### DIFF
--- a/lib/photo_view.dart
+++ b/lib/photo_view.dart
@@ -262,6 +262,7 @@ class PhotoView extends StatefulWidget {
     this.disableGestures,
     this.errorBuilder,
     this.enablePanAlways,
+    this.strictScale,
   })  : child = null,
         childSize = null,
         super(key: key);
@@ -297,6 +298,7 @@ class PhotoView extends StatefulWidget {
     this.filterQuality,
     this.disableGestures,
     this.enablePanAlways,
+    this.strictScale,
   })  : errorBuilder = null,
         imageProvider = null,
         semanticLabel = null,
@@ -409,6 +411,9 @@ class PhotoView extends StatefulWidget {
   /// Enable pan the widget even if it's smaller than the hole parent widget.
   /// Useful when you want to drag a widget without restrictions.
   final bool? enablePanAlways;
+
+  /// Enable strictScale will restrict user scale gesture to the maxScale and minScale values.
+  final bool? strictScale;
 
   bool get _isCustomChild {
     return child != null;
@@ -530,6 +535,7 @@ class _PhotoViewState extends State<PhotoView>
                 filterQuality: widget.filterQuality,
                 disableGestures: widget.disableGestures,
                 enablePanAlways: widget.enablePanAlways,
+                strictScale: widget.strictScale,
               )
             : ImageWrapper(
                 imageProvider: widget.imageProvider!,
@@ -557,6 +563,7 @@ class _PhotoViewState extends State<PhotoView>
                 disableGestures: widget.disableGestures,
                 errorBuilder: widget.errorBuilder,
                 enablePanAlways: widget.enablePanAlways,
+                strictScale: widget.strictScale,
               );
       },
     );

--- a/lib/src/core/photo_view_core.dart
+++ b/lib/src/core/photo_view_core.dart
@@ -42,6 +42,7 @@ class PhotoViewCore extends StatefulWidget {
     required this.filterQuality,
     required this.disableGestures,
     required this.enablePanAlways,
+    required this.strictScale,
   })  : customChild = null,
         super(key: key);
 
@@ -64,6 +65,7 @@ class PhotoViewCore extends StatefulWidget {
     required this.filterQuality,
     required this.disableGestures,
     required this.enablePanAlways,
+    required this.strictScale,
   })  : imageProvider = null,
         semanticLabel = null,
         gaplessPlayback = false,
@@ -91,6 +93,7 @@ class PhotoViewCore extends StatefulWidget {
   final bool tightMode;
   final bool disableGestures;
   final bool enablePanAlways;
+  final bool strictScale;
 
   final FilterQuality filterQuality;
 
@@ -149,6 +152,11 @@ class PhotoViewCoreState extends State<PhotoViewCore>
   void onScaleUpdate(ScaleUpdateDetails details) {
     final double newScale = _scaleBefore! * details.scale;
     final Offset delta = details.focalPoint - _normalizedPosition!;
+
+    if (widget.strictScale && (newScale > widget.scaleBoundaries.maxScale ||
+        newScale < widget.scaleBoundaries.minScale)) {
+      return;
+    }
 
     updateScaleStateFromNewScale(newScale);
 

--- a/lib/src/photo_view_wrappers.dart
+++ b/lib/src/photo_view_wrappers.dart
@@ -33,6 +33,7 @@ class ImageWrapper extends StatefulWidget {
     required this.disableGestures,
     required this.errorBuilder,
     required this.enablePanAlways,
+    required this.strictScale,
   }) : super(key: key);
 
   final ImageProvider imageProvider;
@@ -60,6 +61,7 @@ class ImageWrapper extends StatefulWidget {
   final FilterQuality? filterQuality;
   final bool? disableGestures;
   final bool? enablePanAlways;
+  final bool? strictScale;
 
   @override
   _ImageWrapperState createState() => _ImageWrapperState();
@@ -192,6 +194,7 @@ class _ImageWrapperState extends State<ImageWrapper> {
       controller: widget.controller,
       scaleStateController: widget.scaleStateController,
       scaleStateCycle: widget.scaleStateCycle ?? defaultScaleStateCycle,
+      strictScale: widget.strictScale ?? false,
       scaleBoundaries: scaleBoundaries,
       onTapUp: widget.onTapUp,
       onTapDown: widget.onTapDown,
@@ -251,6 +254,7 @@ class CustomChildWrapper extends StatelessWidget {
     required this.filterQuality,
     required this.disableGestures,
     required this.enablePanAlways,
+    required this.strictScale,
   }) : super(key: key);
 
   final Widget? child;
@@ -278,6 +282,7 @@ class CustomChildWrapper extends StatelessWidget {
   final FilterQuality? filterQuality;
   final bool? disableGestures;
   final bool? enablePanAlways;
+  final bool? strictScale;
 
   @override
   Widget build(BuildContext context) {
@@ -299,6 +304,7 @@ class CustomChildWrapper extends StatelessWidget {
       scaleStateCycle: scaleStateCycle ?? defaultScaleStateCycle,
       basePosition: basePosition ?? Alignment.center,
       scaleBoundaries: scaleBoundaries,
+      strictScale: strictScale ?? false,
       onTapUp: onTapUp,
       onTapDown: onTapDown,
       onScaleEnd: onScaleEnd,


### PR DESCRIPTION
Actual behavior : 
User can scale image in or out. When user release scale gesture, app will rescale if current user scale choice is behind defined limit (maxScale and minScale).

Proposition : 
A new property to prevent the user to scale behind theses limit.