### PR TITLE
Feat/#378 infinite loop gallery

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -5,7 +5,6 @@ linter:
   rules:
     - always_declare_return_types
     - always_put_control_body_on_new_line
-    - always_require_non_null_named_parameters
     - annotate_overrides
     - avoid_classes_with_only_static_members
     - avoid_empty_else
@@ -27,10 +26,8 @@ linter:
     - empty_statements
     - hash_and_equals
     - implementation_imports
-    - iterable_contains_unrelated_type
     - library_names
     - library_prefixes
-    - list_remove_unrelated_type
     - no_adjacent_strings_in_list
     - no_duplicate_case_values
     - non_constant_identifier_names
@@ -71,4 +68,3 @@ linter:
     - unrelated_type_equality_checks
     - use_rethrow_when_possible
     - unnecessary_new
-

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -5,7 +5,6 @@ linter:
   rules:
     - always_declare_return_types
     - always_put_control_body_on_new_line
-    - always_require_non_null_named_parameters
     - annotate_overrides
     - avoid_classes_with_only_static_members
     - avoid_empty_else
@@ -27,10 +26,8 @@ linter:
     - empty_statements
     - hash_and_equals
     - implementation_imports
-    - iterable_contains_unrelated_type
     - library_names
     - library_prefixes
-    - list_remove_unrelated_type
     - no_adjacent_strings_in_list
     - no_duplicate_case_values
     - non_constant_identifier_names
@@ -46,7 +43,6 @@ linter:
     - prefer_const_declarations
     - prefer_const_literals_to_create_immutables
     - prefer_contains
-    - prefer_equal_for_default_values
     - prefer_final_fields
     - prefer_final_locals
     - prefer_foreach

--- a/lib/photo_view_gallery.dart
+++ b/lib/photo_view_gallery.dart
@@ -10,7 +10,6 @@ import 'package:photo_view/photo_view.dart'
         PhotoViewImageTapUpCallback,
         PhotoViewImageScaleEndCallback,
         ScaleStateCycle;
-
 import 'package:photo_view/src/controller/photo_view_controller.dart';
 import 'package:photo_view/src/controller/photo_view_scalestate_controller.dart';
 import 'package:photo_view/src/core/photo_view_gesture_detector.dart';
@@ -126,8 +125,8 @@ class PhotoViewGallery extends StatefulWidget {
   /// The builder must return a [PhotoViewGalleryPageOptions].
   const PhotoViewGallery.builder({
     Key? key,
-    required this.itemCount,
-    required this.builder,
+    required PhotoViewGalleryBuilder this.builder,
+    this.itemCount,
     this.loadingBuilder,
     this.backgroundDecoration,
     this.wantKeepAlive = false,
@@ -142,8 +141,6 @@ class PhotoViewGallery extends StatefulWidget {
     this.customSize,
     this.allowImplicitScrolling = false,
   })  : pageOptions = null,
-        assert(itemCount != null),
-        assert(builder != null),
         super(key: key);
 
   /// A list of options to describe the items in the gallery
@@ -216,11 +213,11 @@ class _PhotoViewGalleryState extends State<PhotoViewGallery> {
     return _controller.hasClients ? _controller.page!.floor() : 0;
   }
 
-  int get itemCount {
+  int? get itemCount {
     if (widget._isBuilder) {
-      return widget.itemCount!;
+      return widget.itemCount;
     }
-    return widget.pageOptions!.length;
+    return widget.pageOptions?.length;
   }
 
   @override


### PR DESCRIPTION
Fix #378 

Made the `itemCount` optional, removed some unneeded assertions and fixed warnings in `analysis_options.yaml`.