### PR TITLE
Delete unreachable `default` clauses.

### DIFF
--- a/lib/photo_view.dart
+++ b/lib/photo_view.dart
@@ -585,8 +585,6 @@ PhotoViewScaleState defaultScaleStateCycle(PhotoViewScaleState actual) {
     case PhotoViewScaleState.zoomedIn:
     case PhotoViewScaleState.zoomedOut:
       return PhotoViewScaleState.initial;
-    default:
-      return PhotoViewScaleState.initial;
   }
 }
 

--- a/lib/src/utils/photo_view_utils.dart
+++ b/lib/src/utils/photo_view_utils.dart
@@ -21,9 +21,6 @@ double getScaleForScaleState(
           scaleBoundaries);
     case PhotoViewScaleState.originalSize:
       return _clampSize(1.0, scaleBoundaries);
-    // Will never be reached
-    default:
-      return 0;
   }
 }
 


### PR DESCRIPTION
The Dart analyzer will soon be changed so that if the `default` clause of a `switch` statement is determined to be unreachable by the exhaustiveness checker, a new warning of type
`unreachable_switch_default` will be issued. This parallels the behavior of the existing `unreachable_switch_case` warning, which is issued whenever a `case` clause of a `switch` statement is determined to be unreachable. For details see
https://github.com/dart-lang/sdk/issues/54575.

This PR deletes unreachable `default` clauses from `photo_view` now, to avoid a spurious warning when the analyzer change lands.